### PR TITLE
Add and Update Mapping Fields

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # ArchivesSpace Request Fulfillment via Aeon
 
-**Version:** 20180111
+**Version:** 20180125
 
-**Last Updated:** January 11, 2018
+**Last Updated:** January 25, 2018
 
 
 ## Table of Contents

--- a/Readme.md
+++ b/Readme.md
@@ -223,6 +223,7 @@ and the values of each may differ from instance to instance.
 - `instance_top_container_restricted`
 - `instance_top_container_created_by`
 - `instance_top_container_indicator`
+- `instance_top_container_barcode`
 - `instance_top_container_type`
 - `instance_top_container_collection_identifier` (semi-colon (`;`) separated string list)
 - `instance_top_container_collection_display_string` (semi-colon (`;`) separated string list)
@@ -271,7 +272,7 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemDate', '<#creation_date>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemTitle', '<#title>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'Location', '<#instance_top_container_long_display_string>', 'NULL');
-INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemNumber', '<#instance_top_container_collection_identifier>|<#instance_top_container_series_identifier>', 'NULL');
+INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemNumber', '<#instance_top_container_barcode>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemISxN', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemCallNumber', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'CallNumber', '<#physical_location_note>|<#collection_id>', 'NULL');

--- a/Readme.md
+++ b/Readme.md
@@ -215,6 +215,7 @@ and the values of each may differ from instance to instance.
 - `instance_container_child_type`
 - `instance_container_last_modified_by`
 - `instance_container_created_by`
+- `instance_top_container_ref`
 - `instance_top_container_uri`
 - `instance_top_container_long_display_string`
 - `instance_top_container_last_modified_by`
@@ -223,18 +224,23 @@ and the values of each may differ from instance to instance.
 - `instance_top_container_created_by`
 - `instance_top_container_indicator`
 - `instance_top_container_type`
+- `instance_top_container_collection_identifier` (semi-colon (`;`) separated string list)
+- `instance_top_container_collection_display_string` (semi-colon (`;`) separated string list)
+- `instance_top_container_series_identifer` (semi-colon (`;`) separated string list)
+- `instance_top_container_series_display_string` (semi-colon (`;`) separated string list)
 
 ### Archival Object Fields
 
-The following fields are specific to requests made for Archival Object 
-records. 
+In addition to the fields specified above, the following additional fields are 
+specific to requests made for Archival Object records. 
 
 - `repository_processing_note`
 - `component_id`
 
 ### Accession Fields
 
-The following fields are specific to requests made for Accession records. 
+In addition to the fields specified above, the following additional fields are 
+specific to requests made for Accession records. 
 
 - `use_restrictions_note`
 - `access_restrictions_note`
@@ -264,8 +270,8 @@ page of our documentation at https://prometheus.atlas-sys.com.
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemAuthor', '<#creators>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemDate', '<#creation_date>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemTitle', '<#title>', 'NULL');
-INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemNumber', '<#barcode_1-container>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'Location', '<#instance_top_container_long_display_string>', 'NULL');
+INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemNumber', '<#instance_top_container_collection_identifier>|<#instance_top_container_series_identifier>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemISxN', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemCallNumber', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'CallNumber', '<#physical_location_note>|<#collection_id>', 'NULL');

--- a/public/lib/record_mapper.rb
+++ b/public/lib/record_mapper.rb
@@ -230,6 +230,33 @@ class RecordMapper
                             request["instance_top_container_created_by_#{instance_count}"] = top_container_resolved['created_by']
                             request["instance_top_container_indicator_#{instance_count}"] = top_container_resolved['indicator']
                             request["instance_top_container_type_#{instance_count}"] = top_container_resolved['type']
+
+                            collection = top_container_resolved['collection']
+                            if collection
+                                request["instance_top_container_collection_identifier_#{instance_count}"] = collection
+                                    .select { |c| c['identifier'].present? }
+                                    .map { |c| c['identifier'] }
+                                    .join("; ")
+
+                                request["instance_top_container_collection_display_string_#{instance_count}"] = collection
+                                    .select { |c| c['display_string'].present? }
+                                    .map { |c| c['display_string'] }
+                                    .join("; ")
+                            end
+
+                            series = top_container_resolved['series']
+                            if series
+                                request["instance_top_container_series_identifier_#{instance_count}"] = series
+                                    .select { |s| s['identifier'].present? }
+                                    .map { |s| s['identifier'] }
+                                    .join("; ")
+
+                                request["instance_top_container_series_display_string_#{instance_count}"] = series
+                                    .select { |s| s['display_string'].present? }
+                                    .map { |s| s['display_string'] }
+                                    .join("; ")
+                            end
+
                         end
                     end
                 end

--- a/public/lib/record_mapper.rb
+++ b/public/lib/record_mapper.rb
@@ -219,7 +219,7 @@ class RecordMapper
 
                     top_container = container['top_container']
                     if top_container
-                        request["instance_top_container_uri_#{instance_count}"] = top_container['uri']
+                        request["instance_top_container_ref_#{instance_count}"] = top_container['ref']
 
                         top_container_resolved = top_container['_resolved']
                         if top_container_resolved
@@ -230,6 +230,7 @@ class RecordMapper
                             request["instance_top_container_created_by_#{instance_count}"] = top_container_resolved['created_by']
                             request["instance_top_container_indicator_#{instance_count}"] = top_container_resolved['indicator']
                             request["instance_top_container_type_#{instance_count}"] = top_container_resolved['type']
+                            request["instance_top_container_uri_#{instance_count}"] = top_container_resolved['uri']
 
                             collection = top_container_resolved['collection']
                             if collection


### PR DESCRIPTION
Added the following fields to the base record mapper:

- `instance_top_container_collection_identifier` 
- `instance_top_container_collection_display_string` 
- `instance_top_container_series_identifer` 
- `instance_top_container_series_display_string` 

Also, the Readme has been updated to include a mapping from either `instance_top_container_collection_identifier` or `instance_top_container_series_identifer` to the ItemNumber field in Aeon, with preference given to the `collection_identifier` field.

All of these added fields are potentially semi-colon separated (`;`) fields. This is because `series` and `collection` are presented as arrays within the set of fields inside the object located at `record` > `instances` > `sub_container` > `top_container` > `_resolved`.

```json
"instances": [
  {
    "sub_container": {
      "top_container": {
        "ref": "/repositories/2/top_containers/59985",
        "_resolved": {
          "series": [
            {
              "ref": "/repositories/2/archival_objects/201496",
              "identifier": "Series 2.",
              "display_string": "Val Verde Estate",
              "level_display_string": "Series",
              "publish": true
            }
          ],
          "collection": [
            {
              "ref": "/repositories/2/resources/1459",
              "identifier": "PA Mss 80",
              "display_string": "Warren Austin papers"
            }
          ],
          "display_string": "Box-folder 4: 17: Series Series 2.",
          "long_display_string": "PA Mss 80, Series Series 2., Box-folder 4: 17"
        }
      }
    }
  }
```

This pull request also fixes the `instance_top_container_uri` mapping and adds the `instance_top_container_ref` field.