### PR TITLE
Add support for custom record mappers.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,14 @@ AppConfig[:aeon_fulfillment] = {
   button to be hidden for accessions, when set to `true`. Defaults to
   `false`.
 
+- **:hide\_button\_for\_access\_restriction\_types**. This setting allows
+  the request button to be hidden for any records that have any of the
+  listed local access restriction types. The value of this config item
+  should be an array of restriction types, for example:
+      `:hide_button_for_access_restriction_types => ['RestrictedSpecColl']`
+  By default no restriction types are hidden.
+
+
 ### Example Configuration
 
 ```ruby

--- a/Readme.md
+++ b/Readme.md
@@ -306,20 +306,15 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 
 The plugin provides default mappers for Accession and ArchivalObject records.
 
-It is possible to override the default mappers by providing a custom mapping class and pointing
-to it in configuration, like this:
+It is possible to override the default mappers by providing a custom mapper class.
+Mapper classes register to handle record types by calling the class method
+#register_for_record_type(type), like this:
 
 ```ruby
-AppConfig[:aeon_fulfillment_mappers] = {
-  'Accession' => 'MyAeonAccessionMapper'
-}
+  register_for_record_type(Accession)
 ```
 
-Where the keys in the hash are `Accession` and/or `ArchivalObject` (ie the names of the model
-classes supported by the plugin), and the values are the names of the custom mapping classes
-provided.
-
-The custom mapping class should inherit from one of the provided mapping classes and then
+The custom mapping class should inherit from one of the provided mapper classes and then
 implement whatever custom mappings are required by overriding the relevant methods. (See
 the default mappers for examples, as they override behavior from the base AeonRecordMapper class)
 

--- a/Readme.md
+++ b/Readme.md
@@ -304,7 +304,13 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 
 ## Custom Mappers
 
-The plugin provides default mappers for Accession and ArchivalObject records.
+The plugin provides default mappers for Accession and ArchivalObject records. To
+support other record types, specify the list of supported record type in
+configuration like this:
+
+```ruby
+  AppConfig[:aeon_fulfillment_record_types] = ['archival_object', 'accession', 'other_record_type']
+```
 
 It is possible to override the default mappers by providing a custom mapper class.
 Mapper classes register to handle record types by calling the class method

--- a/Readme.md
+++ b/Readme.md
@@ -301,3 +301,27 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemCallNumber', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'CallNumber', '<#physical_location_note>|<#collection_id>', 'NULL');
 ```
+
+## Custom Mappers
+
+The plugin provides default mappers for Accession and ArchivalObject records.
+
+It is possible to override the default mappers by providing a custom mapping class and pointing
+to it in configuration, like this:
+
+```ruby
+AppConfig[:aeon_fulfillment_mappers] = {
+  'Accession' => 'MyAeonAccessionMapper'
+}
+```
+
+Where the keys in the hash are `Accession` and/or `ArchivalObject` (ie the names of the model
+classes supported by the plugin), and the values are the names of the custom mapping classes
+provided.
+
+The custom mapping class should inherit from one of the provided mapping classes and then
+implement whatever custom mappings are required by overriding the relevant methods. (See
+the default mappers for examples, as they override behavior from the base AeonRecordMapper class)
+
+The custom mapping class can be loaded from another plugin provided it is listed after this
+plugin in the array of plugins in the configuration.

--- a/Readme.md
+++ b/Readme.md
@@ -159,6 +159,8 @@ AppConfig[:aeon_fulfillment] = {
       `:hide_button_for_access_restriction_types => ['RestrictedSpecColl']`
   By default no restriction types are hidden.
 
+- **:site**. This setting specifies the site code for a repository.
+
 
 ### Example Configuration
 

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -1,5 +1,7 @@
 class AeonAccessionMapper < AeonRecordMapper
 
+    register_for_record_type(Accession)
+
     def initialize(accession)
         super(accession)
     end

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -1,4 +1,4 @@
-class AccessionMapper < RecordMapper
+class AeonAccessionMapper < AeonRecordMapper
 
     def initialize(accession)
         super(accession)

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -1,5 +1,7 @@
 class AeonArchivalObjectMapper < AeonRecordMapper
 
+    register_for_record_type(ArchivalObject)
+
     def initialize(archival_object)
         super(archival_object)
     end

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -1,11 +1,11 @@
-class ArchivalObjectMapper < RecordMapper
-    
+class AeonArchivalObjectMapper < AeonRecordMapper
+
     def initialize(archival_object)
         super(archival_object)
     end
 
 
-    # Override for RecordMapper json_fields method. 
+    # Override for AeonRecordMapper json_fields method. 
     def json_fields
         mappings = super
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -222,7 +222,7 @@ class AeonRecordMapper
         mappings['restrictions_apply'] = json['restrictions_apply']
         mappings['display_string'] = json['display_string']
 
-        instances = json.fetch('instances')
+        instances = json.fetch('instances', false)
         if !instances
             return mappings
         end

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -40,6 +40,15 @@ class AeonRecordMapper
         return true if self.repo_settings.fetch(:hide_request_button, false)
         return true if self.repo_settings.fetch(:hide_button_for_accessions, false) && record.is_a?(Accession)
 
+        if (types = self.repo_settings.fetch(:hide_button_for_access_restriction_types, false))
+          notes = record.json['notes'].select {|n| n['type'] == 'accessrestrict' && n.has_key?('rights_restriction')}
+                                      .map {|n| n['rights_restriction']['local_access_restriction_type']}
+                                      .flatten.uniq
+
+          # hide if the record notes have any of the restriction types listed in config
+          return true if (notes - types).length < notes.length
+        end
+
         false
     end
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -139,6 +139,8 @@ class AeonRecordMapper
                 "ArchivesSpace"
             end
 
+        mappings['Site'] = self.repo_settings[:site] if self.repo_settings.has_key?(:site)
+
         return mappings
     end
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -2,26 +2,21 @@ class AeonRecordMapper
 
     include ManipulateNode
 
+    @@mappers = {}
+
     attr_reader :record
 
     def initialize(record)
         @record = record
     end
 
-    def self.mapper_for(record)
-      unless defined? @@mappers
-        # initialize with the default mappers
-        @@mappers = {
-          'Accession' => 'AeonAccessionMapper', 
-          'ArchivalObject' => 'AeonArchivalObjectMapper' 
-        }
-        if AppConfig.has_key?(:aeon_fulfillment_mappers)
-          @@mappers.merge!(AppConfig[:aeon_fulfillment_mappers])
-        end
-      end
+    def self.register_for_record_type(type)
+      @@mappers[type] = self
+    end
 
-      if @@mappers.has_key?(record.class.to_s)
-        Kernel.const_get(@@mappers[record.class.to_s]).new(record)
+    def self.mapper_for(record)
+      if @@mappers.has_key?(record.class)
+        @@mappers[record.class].new(record)
       else
         Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
         raise

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -1,4 +1,4 @@
-class RecordMapper
+class AeonRecordMapper
 
     include ManipulateNode
 
@@ -6,6 +6,26 @@ class RecordMapper
 
     def initialize(record)
         @record = record
+    end
+
+    def self.mapper_for(record)
+      unless defined? @@mappers
+        # initialize with the default mappers
+        @@mappers = {
+          'Accession' => 'AeonAccessionMapper', 
+          'ArchivalObject' => 'AeonArchivalObjectMapper' 
+        }
+        if AppConfig.has_key?(:aeon_fulfillment_mappers)
+          @@mappers.merge!(AppConfig[:aeon_fulfillment_mappers])
+        end
+      end
+
+      if @@mappers.has_key?(record.class.to_s)
+        Kernel.const_get(@@mappers[record.class.to_s]).new(record)
+      else
+        Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
+        raise
+      end
     end
 
     def repo_code

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,9 +1,7 @@
 ## Register our custom page action
-unless AppConfig.has_key?(:pui_page_custom_actions)
-  AppConfig[:pui_page_custom_actions] << {
-    'record_type' => ['archival_object', 'accession'],
-    'erb_partial' => 'aeon/aeon_request_action'
-  }
-end
+AppConfig[:pui_page_custom_actions] << {
+  'record_type' => ['archival_object', 'accession'],
+  'erb_partial' => 'aeon/aeon_request_action'
+}
 
 

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,6 +1,8 @@
 ## Register our custom page action
+record_types = AppConfig.has_key?(:aeon_fulfillment_record_types) ? AppConfig[:aeon_fulfillment_record_types]
+                                                                  : ['archival_object', 'accession']
 AppConfig[:pui_page_custom_actions] << {
-  'record_type' => ['archival_object', 'accession'],
+  'record_type' => record_types,
   'erb_partial' => 'aeon/aeon_request_action'
 }
 

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,7 +1,9 @@
 ## Register our custom page action
-AppConfig[:pui_page_custom_actions] << {
-  'record_type' => ['archival_object', 'accession'],
-  'erb_partial' => 'aeon/aeon_request_action'
-}
+unless AppConfig.has_key?(:pui_page_custom_actions)
+  AppConfig[:pui_page_custom_actions] << {
+    'record_type' => ['archival_object', 'accession'],
+    'erb_partial' => 'aeon/aeon_request_action'
+  }
+end
 
 

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -1,17 +1,7 @@
 <%
 puts "Aeon Fulfillment Plugin -- Initializing Plugin..."
 
-mapper = case record
-  when ArchivalObject
-    ArchivalObjectMapper.new(record)
-  when Accession
-    AccessionMapper.new(record)
-  else
-    message = "Aeon Fulfillment Plugin -- This ArchivesSpace object type is not supported by this plugin."
-    puts record.inspect
-    puts message
-    raise message
-  end
+mapper = AeonRecordMapper.mapper_for(record)
 %>
 
 <% unless mapper.hide_button? %>


### PR DESCRIPTION
A few changes to support this:
-  Renamed the mappers to include Aeon in the name for a bit of name safety.
-  Replaced the switch in the erb that finds the appropriate mapper for a record
   with a call to a class method (#mapper_for(record)) on the base record mapper class.
-  The class method lazily loads the default mappers and then looks for custom mappers
   in config under the key `AppConfig[:aeon_fulfillment_mappers]`. This can contain
   a hash of custom mappers. (see the Readme for an example)