### PR TITLE
Fixed issue with `has_top_container`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,7 +70,7 @@ of ArchivesSpace may cause changes in the functionality of this plugin.
     - Markup is now stripped from the `title` parameter.
     - Plugin has been refactored so builtin ArchivesSpace functionality can be used.
 - **20180410**
-    - Fixes a bug with the `:requests_permitted_for_containers_only` setting
+    - Fixed a bug with the `:requests_permitted_for_containers_only` setting
 
 ## Configuring Plugin Settings
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,8 @@ of ArchivesSpace may cause changes in the functionality of this plugin.
     - Fixed a bug where only the first container would be included in the request.
     - Markup is now stripped from the `title` parameter.
     - Plugin has been refactored so builtin ArchivesSpace functionality can be used.
-
+- **20180410**
+    - Fixes a bug with the `:requests_permitted_for_containers_only` setting
 
 ## Configuring Plugin Settings
 

--- a/public/models/record_mapper.rb
+++ b/public/models/record_mapper.rb
@@ -39,7 +39,7 @@ class RecordMapper
                 puts "Aeon Fulfillment Plugin -- Checking for top containers"
                 has_top_container = false
 
-                instances = self.record.dig('json', 'instances')
+                instances = self.record.json['instances']
                 if instances
                     instances.each do |instance|
 


### PR DESCRIPTION
`has_top_container` was always evaluating to false. This logic was possibly broken by new releases of ArchivesSpace.

Resolves #5