### PR TITLE
Added the aeon_site_code repo setting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,30 +23,31 @@
 
 ## Overview
 
-This plugin adds a new request button to archival objects that allows 
-researchers to place Aeon requests for archival objects discovered via the 
-ArchivesSpace Public User Interface. 
+This plugin adds a new request button to archival objects that allows
+researchers to place Aeon requests for archival objects discovered via the
+ArchivesSpace Public User Interface.
 
-The functionality provided by this plugin is meant to replace the existing 
-Public UI request action functionality for archival objects. As such, it is 
-recommended that the built in functionality be disabled by setting 
-`AppConfig[:pui_page_actions_request] = false` or by removing `:archival_object`  from your `AppConfig[:pui_requests_permitted_for_types]` 
-setting. The latter will allow you to use Aeon to fulfill archival_object 
-requests, while still allowing other object types to be requested via the 
-default email functionality. By using the 'per repository' configuration 
-options for the built in PUI requesting functionality, it is also possible to 
-configure some repositories to continue using the built in PUI requesting 
-feature for archival objects while allowing other repositories to use Aeon. 
+The functionality provided by this plugin is meant to replace the existing
+Public UI request action functionality for archival objects. As such, it is
+recommended that the built in functionality be disabled by setting
+`AppConfig[:pui_page_actions_request] = false` or by removing
+`:archival_object` from your `AppConfig[:pui_requests_permitted_for_types]`
+setting. The latter will allow you to use Aeon to fulfill archival_object
+requests, while still allowing other object types to be requested via the
+default email functionality. By using the 'per repository' configuration
+options for the built in PUI requesting functionality, it is also possible to
+configure some repositories to continue using the built in PUI requesting
+feature for archival objects while allowing other repositories to use Aeon.
 
-This plugin has been tested on ArchivesSpace version 2.2.0. Future releases 
-of ArchivesSpace may cause changes in the functionality of this plugin. 
+This plugin has been tested on ArchivesSpace version 2.2.0. Future releases of
+ArchivesSpace may cause changes in the functionality of this plugin.
 
 
 ## Changelog
 
 - **20170809** 
     - Initial release of this ArchivesSpace plugin
-    - Added support for sending requests for Archival Objects to Aeon 
+    - Added support for sending requests for Archival Objects to Aeon
 - **20171110**
     - Added readme to include configuration resources
     - Removed an unused control
@@ -59,24 +60,31 @@ of ArchivesSpace may cause changes in the functionality of this plugin.
     - Bug fixes
 - **20180222**
     - Removed explicit references to aeon.dll from the ruby partial
-    - This change was made to support Aeon installations that don't specify an explicit
-    `aeon.dll` in the `:aeon_web_url`
-    - If updating to or past this version, you may need to add `aeon.dll` to your settings 
-    for `:aeon_web_url`
+    - This change was made to support Aeon installations that don't specify an
+      explicit `aeon.dll` in the `:aeon_web_url`
+    - If updating to or past this version, you may need to add `aeon.dll` to
+      your settings for `:aeon_web_url`
 - **20180319**
-    - Added the `:request_in_new_tab`, `:hide_request_button`, and `:hide_button_for_accessions` 
-    settings. All are optional and default to false.
-    - Fixed a bug where only the first container would be included in the request.
+    - Added the `:request_in_new_tab`, `:hide_request_button`, and
+      `:hide_button_for_accessions` settings. All are optional and default to
+      false.
+    - Fixed a bug where only the first container would be included in the
+      request.
     - Markup is now stripped from the `title` parameter.
-    - Plugin has been refactored so builtin ArchivesSpace functionality can be used.
-- **20180410**
+    - Plugin has been refactored so builtin ArchivesSpace functionality can be
+      used.
+- **20180524**
     - Fixed a bug with the `:requests_permitted_for_containers_only` setting
+    - Added an `:aeon_site_code` setting, allowing sites to specify the Aeon
+      site code that should be put into the Site field of the Aeon Transaction
+      record.
+
 
 ## Configuring Plugin Settings
 
-In order to configure this plugin, you will need to modify the 
-`config/config.rb` file of your ArchivesSpace installation. To enable the 
-plugin, you will need to add the following to the configuration file. 
+In order to configure this plugin, you will need to modify the
+`config/config.rb` file of your ArchivesSpace installation. To enable the
+plugin, you will need to add the following to the configuration file.
 
 ```ruby
 AppConfig[:plugins] << 'aeon_fulfillment'
@@ -104,6 +112,7 @@ AppConfig[:aeon_fulfillment] = {}
 AppConfig[:aeon_fulfillment]['atlas'] = {}
 AppConfig[:aeon_fulfillment]['atlas'][:aeon_web_url] = "https://your.institution.edu/aeon/aeon.dll"
 AppConfig[:aeon_fulfillment]['atlas'][:aeon_return_link_label] = "ArchivesSpace"
+AppConfig[:aeon_fulfillment]['atlas'][:aeon_site_code] = "AEON"
 ```
 
 This plugin configuration can also be formatted using the implicit form of a 
@@ -118,6 +127,7 @@ AppConfig[:aeon_fulfillment] = {
     },
     "test-repo" => {
         :aeon_web_url => "https://your.institution.edu/aeon/aeon.dll",
+        :aeon_site_code => "TEST",
         :aeon_external_system_id => "ArchivesSpace Test Tepo"
     }
 }
@@ -153,6 +163,13 @@ AppConfig[:aeon_fulfillment] = {
   button to be hidden for accessions, when set to `true`. Defaults to
   `false`.
 
+- **:aeon\_site\_code**. This setting specifies the string that is sent with
+  the request in a field labeled `aeon_site_code`. This setting will not
+  automatically set the `Site` field on the Aeon Transaction record. The site
+  field has to be manually configured through the `OpenURLMapping` table. If 
+  this setting is not specified in the settings for the repository, no Aeon
+  site code will be sent.
+
 ### Example Configuration
 
 ```ruby
@@ -160,16 +177,18 @@ AppConfig[:plugins] << "aeon_fulfillment"
 
 AppConfig[:aeon_fulfillment] = {
     "special research collections" => {
-        :aeon_web_url => "https://your.institution.edu/aeon/aeon.dll",        
+        :aeon_web_url => "https://your.institution.edu/aeon/aeon.dll",
         :aeon_return_link_label => "Back to ArchivesSpace",
         :aeon_external_system_id => "ArchivesSpace",
+        :aeon_site_code => "SPECCOLL",
         :requests_permitted_for_containers_only => true
     },
     "test special collections" => {
         :aeon_web_url => "https://your.institution.edu/aeon/aeon.dll",
         :aeon_return_link_label => "Back to ArchivesSpace",
         :aeon_external_system_id => "ArchivesSpace Test",
-        :requests_permitted_for_containers_only => false        
+        :aeon_site_code => "TEST",
+        :requests_permitted_for_containers_only => false
     }
 }
 ```
@@ -177,18 +196,19 @@ AppConfig[:aeon_fulfillment] = {
 
 ## Imported Fields
 
-This plugin builds a form that is sent to Aeon through the external requests 
-(`?action=11&type=200`) endpoint of the Aeon Web interface. Below are 
-the names of the fields as they will appear in the request. 
+This plugin builds a form that is sent to Aeon through the external requests
+(`?action=11&type=200`) endpoint of the Aeon Web interface. Below are the
+names of the fields as they will appear in the request.
 
 ### Common Fields
 
-These fields are imported from both Archival Object records and Accession 
-records. 
+These fields are imported from both Archival Object records and Accession
+records.
 
 - `SystemID`
 - `ReturnLinkURL`
 - `ReturnLinkSystemName`
+- `aeon_site_code`
 - `identifier`
 - `publish` (true/false value)
 - `level`
@@ -222,12 +242,12 @@ records.
       is controlled by the `date_label` enumeration of your ArchivesSpace 
       installation. 
 
-The following fields are common to both Accession records and Archival Object 
-records, but are based on the number of instances associated with the record. 
-The number of requests sent to Aeon is equal to the number of instances 
-associated with the record. If there are no instances, only one request will 
-be sent to Aeon. All of these fields are dependant on the number of instances, 
-and the values of each may differ from instance to instance. 
+The following fields are common to both Accession records and Archival Object
+records, but are based on the number of instances associated with the record.
+The number of requests sent to Aeon is equal to the number of instances
+associated with the record. If there are no instances, only one request will
+be sent to Aeon. All of these fields are dependant on the number of instances,
+and the values of each may differ from instance to instance.
 
 - `instance_is_representative`
 - `instance_last_modified_by`
@@ -256,16 +276,16 @@ and the values of each may differ from instance to instance.
 
 ### Archival Object Fields
 
-In addition to the fields specified above, the following additional fields are 
-specific to requests made for Archival Object records. 
+In addition to the fields specified above, the following additional fields are
+specific to requests made for Archival Object records.
 
 - `repository_processing_note`
 - `component_id`
 
 ### Accession Fields
 
-In addition to the fields specified above, the following additional fields are 
-specific to requests made for Accession records. 
+In addition to the fields specified above, the following additional fields are
+specific to requests made for Accession records.
 
 - `use_restrictions_note`
 - `access_restrictions_note`
@@ -293,6 +313,7 @@ For more information on configuring Aeon for this system, please visit the
 page of our documentation at https://prometheus.atlas-sys.com.
 
 ```sql
+INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'Site', '<#aeon_site_code>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemAuthor', '<#creators>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemDate', '<#creation_date>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemTitle', '<#title>', 'NULL');

--- a/public/models/record_mapper.rb
+++ b/public/models/record_mapper.rb
@@ -115,6 +115,10 @@ class RecordMapper
                 "ArchivesSpace"
             end
 
+        if (!self.repo_settings[:aeon_site_code].blank?)
+            mappings['aeon_site_code'] = self.repo_settings[:aeon_site_code]
+        end
+
         return mappings
     end
 


### PR DESCRIPTION
Added a setting that allows sites to optionally configure 1 Aeon site code per ArchivesSpace repository.

There is a pretty sizable diff due to reformatting the README. The only relevant code changes are in  `public/models/record_mapper.rb`.

Closes #10 .