### PR TITLE
Yale mods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -331,20 +331,15 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 
 The plugin provides default mappers for Accession and ArchivalObject records.
 
-It is possible to override the default mappers by providing a custom mapping class and pointing
-to it in configuration, like this:
+It is possible to override the default mappers by providing a custom mapper class.
+Mapper classes register to handle record types by calling the class method
+#register_for_record_type(type), like this:
 
 ```ruby
-AppConfig[:aeon_fulfillment_mappers] = {
-  'Accession' => 'MyAeonAccessionMapper'
-}
+  register_for_record_type(Accession)
 ```
 
-Where the keys in the hash are `Accession` and/or `ArchivalObject` (ie the names of the model
-classes supported by the plugin), and the values are the names of the custom mapping classes
-provided.
-
-The custom mapping class should inherit from one of the provided mapping classes and then
+The custom mapping class should inherit from one of the provided mapper classes and then
 implement whatever custom mappings are required by overriding the relevant methods. (See
 the default mappers for examples, as they override behavior from the base AeonRecordMapper class)
 

--- a/Readme.md
+++ b/Readme.md
@@ -326,3 +326,27 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemCallNumber', '<#physical_location_note>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'CallNumber', '<#physical_location_note>|<#collection_id>', 'NULL');
 ```
+
+## Custom Mappers
+
+The plugin provides default mappers for Accession and ArchivalObject records.
+
+It is possible to override the default mappers by providing a custom mapping class and pointing
+to it in configuration, like this:
+
+```ruby
+AppConfig[:aeon_fulfillment_mappers] = {
+  'Accession' => 'MyAeonAccessionMapper'
+}
+```
+
+Where the keys in the hash are `Accession` and/or `ArchivalObject` (ie the names of the model
+classes supported by the plugin), and the values are the names of the custom mapping classes
+provided.
+
+The custom mapping class should inherit from one of the provided mapping classes and then
+implement whatever custom mappings are required by overriding the relevant methods. (See
+the default mappers for examples, as they override behavior from the base AeonRecordMapper class)
+
+The custom mapping class can be loaded from another plugin provided it is listed after this
+plugin in the array of plugins in the configuration.

--- a/Readme.md
+++ b/Readme.md
@@ -180,6 +180,8 @@ AppConfig[:aeon_fulfillment] = {
       `:hide_button_for_access_restriction_types => ['RestrictedSpecColl']`
   By default no restriction types are hidden.
 
+- **:site**. This setting specifies the site code for a repository.
+
 
 ### Example Configuration
 

--- a/Readme.md
+++ b/Readme.md
@@ -166,12 +166,9 @@ AppConfig[:aeon_fulfillment] = {
   button to be hidden for accessions, when set to `true`. Defaults to
   `false`.
 
-- **:aeon\_site\_code**. This setting specifies the string that is sent with
-  the request in a field labeled `aeon_site_code`. This setting will not
-  automatically set the `Site` field on the Aeon Transaction record. The site
-  field has to be manually configured through the `OpenURLMapping` table. If 
-  this setting is not specified in the settings for the repository, no Aeon
-  site code will be sent.
+- **:aeon\_site\_code**. This setting specifies the Aeon site code for a
+  repository. If this setting is not specified in the settings for the
+  repository, no Aeon site code will be sent.
 
 - **:hide\_button\_for\_access\_restriction\_types**. This setting allows
   the request button to be hidden for any records that have any of the
@@ -179,8 +176,6 @@ AppConfig[:aeon_fulfillment] = {
   should be an array of restriction types, for example:
       `:hide_button_for_access_restriction_types => ['RestrictedSpecColl']`
   By default no restriction types are hidden.
-
-- **:site**. This setting specifies the site code for a repository.
 
 
 ### Other Configuration Options
@@ -342,7 +337,6 @@ For more information on configuring Aeon for this system, please visit the
 page of our documentation at https://prometheus.atlas-sys.com.
 
 ```sql
-INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'Site', '<#aeon_site_code>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemAuthor', '<#creators>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemDate', '<#creation_date>', 'NULL');
 INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLFieldValues, AeonValue) VALUES ('Default', 'ArchivesSpace', 'Replace', 'ItemTitle', '<#title>', 'NULL');

--- a/Readme.md
+++ b/Readme.md
@@ -173,6 +173,14 @@ AppConfig[:aeon_fulfillment] = {
   this setting is not specified in the settings for the repository, no Aeon
   site code will be sent.
 
+- **:hide\_button\_for\_access\_restriction\_types**. This setting allows
+  the request button to be hidden for any records that have any of the
+  listed local access restriction types. The value of this config item
+  should be an array of restriction types, for example:
+      `:hide_button_for_access_restriction_types => ['RestrictedSpecColl']`
+  By default no restriction types are hidden.
+
+
 ### Example Configuration
 
 ```ruby

--- a/Readme.md
+++ b/Readme.md
@@ -189,8 +189,8 @@ The following configuration options apply globally, rather than for a particular
 repository.
 
 - **:aeon\_fulfillment\_record\_types**. This setting takes an array of record
-  types. It allows this plugin to handle additional record types via custom mappers
-  - see below.
+  types. It allows this plugin to handle additional record types via custom
+  mappers - see below.
 
 - **:aeon\_fulfillment\_button\_position**. This setting supports the positioning
   of the request button relative to the other buttons appearing on a page. By default

--- a/Readme.md
+++ b/Readme.md
@@ -329,7 +329,13 @@ INSERT INTO OpenURLMapping (URL_Ver, rfr_id, AeonAction, AeonFieldName, OpenURLF
 
 ## Custom Mappers
 
-The plugin provides default mappers for Accession and ArchivalObject records.
+The plugin provides default mappers for Accession and ArchivalObject records. To
+support other record types, specify the list of supported record type in
+configuration like this:
+
+```ruby
+  AppConfig[:aeon_fulfillment_record_types] = ['archival_object', 'accession', 'other_record_type']
+```
 
 It is possible to override the default mappers by providing a custom mapper class.
 Mapper classes register to handle record types by calling the class method

--- a/Readme.md
+++ b/Readme.md
@@ -136,7 +136,7 @@ AppConfig[:aeon_fulfillment] = {
 }
 ```
 
-### All Aeon Fulfillment Plugin Configuration Options
+### All Aeon Fulfillment Plugin Per Repository Configuration Options
 
 - **:aeon\_web\_url**. (Required). This setting specifies the web url that 
   points to an Aeon installation. The plugin will send requests to this url, 
@@ -181,6 +181,22 @@ AppConfig[:aeon_fulfillment] = {
   By default no restriction types are hidden.
 
 - **:site**. This setting specifies the site code for a repository.
+
+
+### Other Configuration Options
+
+The following configuration options apply globally, rather than for a particular
+repository.
+
+- **:aeon\_fulfillment\_record\_types**. This setting takes an array of record
+  types. It allows this plugin to handle additional record types via custom mappers
+  - see below.
+
+- **:aeon\_fulfillment\_button\_position**. This setting supports the positioning
+  of the request button relative to the other buttons appearing on a page. By default
+  the button will appear to the right of all built in buttons and to the left of any
+  plugin buttons loaded after it. Setting this to `0` will cause the request button
+  to appear to the left of the built in buttons.
 
 
 ### Example Configuration

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -1,5 +1,7 @@
 class AeonAccessionMapper < AeonRecordMapper
 
+    register_for_record_type(Accession)
+
     def initialize(accession)
         super(accession)
     end

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -1,4 +1,4 @@
-class AccessionMapper < RecordMapper
+class AeonAccessionMapper < AeonRecordMapper
 
     def initialize(accession)
         super(accession)

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -1,5 +1,7 @@
 class AeonArchivalObjectMapper < AeonRecordMapper
 
+    register_for_record_type(ArchivalObject)
+
     def initialize(archival_object)
         super(archival_object)
     end

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -1,11 +1,11 @@
-class ArchivalObjectMapper < RecordMapper
-    
+class AeonArchivalObjectMapper < AeonRecordMapper
+
     def initialize(archival_object)
         super(archival_object)
     end
 
 
-    # Override for RecordMapper json_fields method. 
+    # Override for AeonRecordMapper json_fields method. 
     def json_fields
         mappings = super
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -80,6 +80,10 @@ class AeonRecordMapper
 
                 only_top_containers = self.repo_settings[:requests_permitted_for_containers_only] || false
 
+                # if we're showing the button for accessions, and this is an accession,
+                # then don't require containers
+                only_top_containers = self.repo_settings.fetch(:hide_button_for_accessions, false) if record.is_a?(Accession)
+
                 puts "Aeon Fulfillment Plugin -- Containers found?    #{has_top_container}"
                 puts "Aeon Fulfillment Plugin -- only_top_containers? #{only_top_containers}"
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -41,9 +41,9 @@ class AeonRecordMapper
         return true if self.repo_settings.fetch(:hide_button_for_accessions, false) && record.is_a?(Accession)
 
         if (types = self.repo_settings.fetch(:hide_button_for_access_restriction_types, false))
-          notes = record.json['notes'].select {|n| n['type'] == 'accessrestrict' && n.has_key?('rights_restriction')}
-                                      .map {|n| n['rights_restriction']['local_access_restriction_type']}
-                                      .flatten.uniq
+          notes = (record.json['notes'] || []).select {|n| n['type'] == 'accessrestrict' && n.has_key?('rights_restriction')}
+                                              .map {|n| n['rights_restriction']['local_access_restriction_type']}
+                                              .flatten.uniq
 
           # hide if the record notes have any of the restriction types listed in config
           return true if (notes - types).length < notes.length

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -145,11 +145,7 @@ class AeonRecordMapper
                 "ArchivesSpace"
             end
 
-        if (!self.repo_settings[:aeon_site_code].blank?)
-            mappings['aeon_site_code'] = self.repo_settings[:aeon_site_code]
-        end
-
-        mappings['Site'] = self.repo_settings[:site] if self.repo_settings.has_key?(:site)
+        mappings['Site'] = self.repo_settings[:aeon_site_code] if self.repo_settings.has_key?(:aeon_site_code)
 
         return mappings
     end

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -40,6 +40,15 @@ class AeonRecordMapper
         return true if self.repo_settings.fetch(:hide_request_button, false)
         return true if self.repo_settings.fetch(:hide_button_for_accessions, false) && record.is_a?(Accession)
 
+        if (types = self.repo_settings.fetch(:hide_button_for_access_restriction_types, false))
+          notes = record.json['notes'].select {|n| n['type'] == 'accessrestrict' && n.has_key?('rights_restriction')}
+                                      .map {|n| n['rights_restriction']['local_access_restriction_type']}
+                                      .flatten.uniq
+
+          # hide if the record notes have any of the restriction types listed in config
+          return true if (notes - types).length < notes.length
+        end
+
         false
     end
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -78,6 +78,8 @@ class AeonRecordMapper
                     end
                 end
 
+                has_top_container = true if record.is_a?(Container)
+
                 only_top_containers = self.repo_settings[:requests_permitted_for_containers_only] || false
 
                 # if we're showing the button for accessions, and this is an accession,

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -143,6 +143,8 @@ class AeonRecordMapper
             mappings['aeon_site_code'] = self.repo_settings[:aeon_site_code]
         end
 
+        mappings['Site'] = self.repo_settings[:site] if self.repo_settings.has_key?(:site)
+
         return mappings
     end
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -2,26 +2,21 @@ class AeonRecordMapper
 
     include ManipulateNode
 
+    @@mappers = {}
+
     attr_reader :record
 
     def initialize(record)
         @record = record
     end
 
-    def self.mapper_for(record)
-      unless defined? @@mappers
-        # initialize with the default mappers
-        @@mappers = {
-          'Accession' => 'AeonAccessionMapper', 
-          'ArchivalObject' => 'AeonArchivalObjectMapper' 
-        }
-        if AppConfig.has_key?(:aeon_fulfillment_mappers)
-          @@mappers.merge!(AppConfig[:aeon_fulfillment_mappers])
-        end
-      end
+    def self.register_for_record_type(type)
+      @@mappers[type] = self
+    end
 
-      if @@mappers.has_key?(record.class.to_s)
-        Kernel.const_get(@@mappers[record.class.to_s]).new(record)
+    def self.mapper_for(record)
+      if @@mappers.has_key?(record.class)
+        @@mappers[record.class].new(record)
       else
         Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
         raise

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -1,4 +1,4 @@
-class RecordMapper
+class AeonRecordMapper
 
     include ManipulateNode
 
@@ -6,6 +6,26 @@ class RecordMapper
 
     def initialize(record)
         @record = record
+    end
+
+    def self.mapper_for(record)
+      unless defined? @@mappers
+        # initialize with the default mappers
+        @@mappers = {
+          'Accession' => 'AeonAccessionMapper', 
+          'ArchivalObject' => 'AeonArchivalObjectMapper' 
+        }
+        if AppConfig.has_key?(:aeon_fulfillment_mappers)
+          @@mappers.merge!(AppConfig[:aeon_fulfillment_mappers])
+        end
+      end
+
+      if @@mappers.has_key?(record.class.to_s)
+        Kernel.const_get(@@mappers[record.class.to_s]).new(record)
+      else
+        Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
+        raise
+      end
     end
 
     def repo_code

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -226,7 +226,7 @@ class AeonRecordMapper
         mappings['restrictions_apply'] = json['restrictions_apply']
         mappings['display_string'] = json['display_string']
 
-        instances = json.fetch('instances')
+        instances = json.fetch('instances', false)
         if !instances
             return mappings
         end

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,9 +1,7 @@
 ## Register our custom page action
-unless AppConfig.has_key?(:pui_page_custom_actions)
-  AppConfig[:pui_page_custom_actions] << {
-    'record_type' => ['archival_object', 'accession'],
-    'erb_partial' => 'aeon/aeon_request_action'
-  }
-end
+AppConfig[:pui_page_custom_actions] << {
+  'record_type' => ['archival_object', 'accession'],
+  'erb_partial' => 'aeon/aeon_request_action'
+}
 
 

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,6 +1,8 @@
 ## Register our custom page action
+record_types = AppConfig.has_key?(:aeon_fulfillment_record_types) ? AppConfig[:aeon_fulfillment_record_types]
+                                                                  : ['archival_object', 'accession']
 AppConfig[:pui_page_custom_actions] << {
-  'record_type' => ['archival_object', 'accession'],
+  'record_type' => record_types,
   'erb_partial' => 'aeon/aeon_request_action'
 }
 

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,9 +1,9 @@
 ## Register our custom page action
 record_types = AppConfig.has_key?(:aeon_fulfillment_record_types) ? AppConfig[:aeon_fulfillment_record_types]
                                                                   : ['archival_object', 'accession']
-AppConfig[:pui_page_custom_actions] << {
-  'record_type' => record_types,
-  'erb_partial' => 'aeon/aeon_request_action'
-}
 
+button_position = AppConfig.has_key?(:aeon_fulfillment_button_position) ? AppConfig[:aeon_fulfillment_button_position] : nil
 
+Plugins::add_record_page_action_erb(record_types,
+                                    'aeon/aeon_request_action',
+                                    button_position)

--- a/public/plugin_init.rb
+++ b/public/plugin_init.rb
@@ -1,7 +1,9 @@
 ## Register our custom page action
-AppConfig[:pui_page_custom_actions] << {
-  'record_type' => ['archival_object', 'accession'],
-  'erb_partial' => 'aeon/aeon_request_action'
-}
+unless AppConfig.has_key?(:pui_page_custom_actions)
+  AppConfig[:pui_page_custom_actions] << {
+    'record_type' => ['archival_object', 'accession'],
+    'erb_partial' => 'aeon/aeon_request_action'
+  }
+end
 
 

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -1,17 +1,7 @@
 <%
 puts "Aeon Fulfillment Plugin -- Initializing Plugin..."
 
-mapper = case record
-  when ArchivalObject
-    ArchivalObjectMapper.new(record)
-  when Accession
-    AccessionMapper.new(record)
-  else
-    message = "Aeon Fulfillment Plugin -- This ArchivesSpace object type is not supported by this plugin."
-    puts record.inspect
-    puts message
-    raise message
-  end
+mapper = AeonRecordMapper.mapper_for(record)
 %>
 
 <% unless mapper.hide_button? %>


### PR DESCRIPTION
A few changes from the work for Yale:

  - Added support for custom record mappers (eg [yale_aeon_mappings](https://github.com/hudmol/yale_aeon_mappings))
  - Don't throw an error if a record doesn't have an instances array
  - Added support for specifying supported record types from config
  - Added support for hiding the button for records that have access restriction types
  - Added support for configuring a site code for a repository
  - Use the provided method for adding the button rather than pushing to config
  - Added support for button position
  - Show the button for accessions that don't have containers
  - If the record is a container then treat it as a record that has a container

I noticed that an option has been added for setting `aeon_site_code` from config. I've left my alternative implementation in because it doesn't conflict and doesn't require an open url mapping. Happy to discuss.

