### PR TITLE
Added accessible hover text to the "Aeon Request" button, when disabled

### DIFF
--- a/public/assets/css/aeon_request_action.css
+++ b/public/assets/css/aeon_request_action.css
@@ -1,0 +1,18 @@
+#disabled-button-wrapper {
+  display: inline-block;
+  cursor: not-allowed;
+}
+
+#disabled-button-wrapper .btn[disabled] {
+  pointer-events: none;
+}
+
+.visually-hidden {
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/public/assets/js/aeon_request_action.js
+++ b/public/assets/js/aeon_request_action.js
@@ -1,0 +1,18 @@
+$(document).ready(function() {
+    $('[rel="tooltip"]').tooltip()
+    .on("mouseenter", function() {
+        var _this = this;
+        $(this).tooltip("show");
+        $(".tooltip").on("mouseleave", function () {
+            $(_this).tooltip('hide');
+        });
+    })
+    .on("mouseleave", function() {
+        var _this = this;
+        setTimeout(function() {
+            if (!$(".tooltip:hover").length) {
+                $(_this).tooltip("hide");
+            }
+        }, 300);
+    })
+});

--- a/public/assets/js/aeon_request_action.js
+++ b/public/assets/js/aeon_request_action.js
@@ -1,18 +1,3 @@
 $(document).ready(function() {
-    $('[rel="tooltip"]').tooltip()
-    .on("mouseenter", function() {
-        var _this = this;
-        $(this).tooltip("show");
-        $(".tooltip").on("mouseleave", function () {
-            $(_this).tooltip('hide');
-        });
-    })
-    .on("mouseleave", function() {
-        var _this = this;
-        setTimeout(function() {
-            if (!$(".tooltip:hover").length) {
-                $(_this).tooltip("hide");
-            }
-        }, 300);
-    })
+    $('#disabled-button-wrapper').tooltip()
 });

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -3,4 +3,4 @@ en:
     aeon_fulfillment:
       request_button_icon: fa fa-external-link fa-3x
       request_button_label: Aeon Request
-      requesting_disabled: This record cannot be sent in a request.
+      requesting_disabled: Requesting is not available for this record.

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -165,7 +165,17 @@ class AeonRecordMapper
         if resolved_resource
             resource_obj = resolved_resource[self.record['resource']]
             if resource_obj
-                mappings['collection_id'] = "#{resource_obj[0]['id_0']} #{resource_obj[0]['id_1']} #{resource_obj[0]['id_2']} #{resource_obj[0]['id_3']}".rstrip
+                collection_id_components = [
+                    resource_obj[0]['id_0'],
+                    resource_obj[0]['id_1'],
+                    resource_obj[0]['id_2'],
+                    resource_obj[0]['id_3']
+                ]
+
+                mappings['collection_id'] = collection_id_components
+                    .reject {|id_comp| id_comp.blank?}
+                    .join('-')
+                    
                 mappings['collection_title'] = resource_obj[0]['title']
             end
         end

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -4,6 +4,8 @@ puts "Aeon Fulfillment Plugin -- Initializing Plugin..."
 mapper = AeonRecordMapper.mapper_for(record)
 %>
 
+<%= javascript_include_tag "#{@base_url}/assets/js/aeon_request_action.js" %>
+
 <% unless mapper.hide_button? %>
 
   <% if mapper.show_action? %>
@@ -27,9 +29,12 @@ mapper = AeonRecordMapper.mapper_for(record)
 
   <% else %>
 
-    <button class="btn btn-default page_action request" disabled="true">
-      <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
-    </button>
+    <div id="disabled-button-wrapper" tabindex="0" rel="tooltip" data-placement="bottom" data-toggle="tooltip" data-html="true" data-trigger="manual" data-title="<%= t('plugins.aeon_fulfillment.requesting_disabled') %>">
+      <button class="btn btn-default page_action request" disabled="true" aria-disabled="true" >
+        <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
+      </button>
+      <span class="visually-hidden"><%= t('plugins.aeon_fulfillment.requesting_disabled') %></span>
+    </div>
 
   <% end %>
 

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -22,18 +22,18 @@ mapper = AeonRecordMapper.mapper_for(record)
         <% end %>
       <% end %>
 
-      <button type="submit" class="btn page_action request btn-default" title="<%= t('plugins.aeon_fulfillment.request_button_label') %>">
+      <button id="aeon-fulfillment-request" type="submit" class="btn page_action request btn-default" title="<%= t('plugins.aeon_fulfillment.request_button_label') %>">
         <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
       </button>
     <% end %>
 
   <% else %>
 
-    <div id="disabled-button-wrapper" tabindex="0" rel="tooltip" data-placement="bottom" data-toggle="tooltip" data-html="true" data-trigger="manual" data-title="<%= t('plugins.aeon_fulfillment.requesting_disabled') %>">
-      <button class="btn btn-default page_action request" disabled="true" aria-disabled="true" >
+    <div id="disabled-button-wrapper" tabindex="0" rel="tooltip" data-placement="bottom" title="<%= t('plugins.aeon_fulfillment.requesting_disabled') %>">
+      <button id="disabled-aeon-fulfillment-request" class="btn btn-default page_action request" disabled="true" aria-disabled="true">
         <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
+        <span class="visually-hidden"><%= t('plugins.aeon_fulfillment.requesting_disabled') %></span>
       </button>
-      <span class="visually-hidden"><%= t('plugins.aeon_fulfillment.requesting_disabled') %></span>
     </div>
 
   <% end %>

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -22,7 +22,7 @@ mapper = AeonRecordMapper.mapper_for(record)
         <% end %>
       <% end %>
 
-      <button id="aeon-fulfillment-request" type="submit" class="btn page_action request btn-default" title="<%= t('plugins.aeon_fulfillment.request_button_label') %>">
+      <button type="submit" class="btn page_action request btn-default" title="<%= t('plugins.aeon_fulfillment.request_button_label') %>">
         <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
       </button>
     <% end %>

--- a/public/views/layout_head.html.erb
+++ b/public/views/layout_head.html.erb
@@ -1,0 +1,1 @@
+<%= stylesheet_link_tag "#{@base_url}/assets/css/aeon_request_action.css" %>


### PR DESCRIPTION
When the Aeon Request button is disabled, the button will be surrounded with an invisible and tab-able div, that displays a tooltip on tab and on hover. The message of this tooltip is configurable in the locales. The button will also have a "visually hidden" span that contains the same text as tooltip, allowing screen readers to find and say the message.

![image](https://user-images.githubusercontent.com/16184219/50614732-cfce9a00-0eaf-11e9-9392-05969e3efc50.png)

ChromeVox reads the button as "Aeon Request Requesting is not available for this record."

This PR also changes the formatting of the `collection_id` POST field, delimiting the identifier components with dashes, instead of spaces.

Closes #17 