### PR TITLE
Enhancement: Pull in instance information from a parent object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build-iPhoneSimulator/
 .rvmrc
 
 .DS_Store
+.idea

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -67,7 +67,6 @@ class AeonRecordMapper
             else
                 puts "Aeon Fulfillment Plugin -- Checking for top containers"
 
-                # TODO: length of self.container_instances
                 has_top_container = record.is_a?(Container) || self.container_instances.any?
 
                 only_top_containers = self.repo_settings[:requests_permitted_for_containers_only] || false

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -316,6 +316,9 @@ class AeonRecordMapper
         return mappings
     end
 
+    def find_instances (record)
 
-    protected :json_fields, :record_fields, :system_information
+    end
+
+    protected :json_fields, :record_fields, :system_information, :find_instances
 end

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -255,59 +255,59 @@ class AeonRecordMapper
                 request["instance_created_by_#{instance_count}"] = instance['created_by']
 
                 container = instance['sub_container']
-                if container
-                    request["instance_container_grandchild_indicator_#{instance_count}"] = container['indicator_3']
-                    request["instance_container_child_indicator_#{instance_count}"] = container['indicator_2']
-                    request["instance_container_grandchild_type_#{instance_count}"] = container['type_3']
-                    request["instance_container_child_type_#{instance_count}"] = container['type_2']
+                return request unless container
 
-                    request["instance_container_last_modified_by_#{instance_count}"] = container['last_modified_by']
-                    request["instance_container_created_by_#{instance_count}"] = container['created_by']
+                request["instance_container_grandchild_indicator_#{instance_count}"] = container['indicator_3']
+                request["instance_container_child_indicator_#{instance_count}"] = container['indicator_2']
+                request["instance_container_grandchild_type_#{instance_count}"] = container['type_3']
+                request["instance_container_child_type_#{instance_count}"] = container['type_2']
+                request["instance_container_last_modified_by_#{instance_count}"] = container['last_modified_by']
+                request["instance_container_created_by_#{instance_count}"] = container['created_by']
 
-                    top_container = container['top_container']
-                    if top_container
-                        request["instance_top_container_ref_#{instance_count}"] = top_container['ref']
+                top_container = container['top_container']
+                return request unless top_container
 
-                        top_container_resolved = top_container['_resolved']
-                        if top_container_resolved
-                            request["instance_top_container_long_display_string_#{instance_count}"] = top_container_resolved['long_display_string']
-                            request["instance_top_container_last_modified_by_#{instance_count}"] = top_container_resolved['last_modified_by']
-                            request["instance_top_container_display_string_#{instance_count}"] = top_container_resolved['display_string']
-                            request["instance_top_container_restricted_#{instance_count}"] = top_container_resolved['restricted']
-                            request["instance_top_container_created_by_#{instance_count}"] = top_container_resolved['created_by']
-                            request["instance_top_container_indicator_#{instance_count}"] = top_container_resolved['indicator']
-                            request["instance_top_container_barcode_#{instance_count}"] = top_container_resolved['barcode']
-                            request["instance_top_container_type_#{instance_count}"] = top_container_resolved['type']
-                            request["instance_top_container_uri_#{instance_count}"] = top_container_resolved['uri']
+                request["instance_top_container_ref_#{instance_count}"] = top_container['ref']
 
-                            collection = top_container_resolved['collection']
-                            if collection
-                                request["instance_top_container_collection_identifier_#{instance_count}"] = collection
-                                    .select { |c| c['identifier'].present? }
-                                    .map { |c| c['identifier'] }
-                                    .join("; ")
+                top_container_resolved = top_container['_resolved']
+                return request unless top_container_resolved
 
-                                request["instance_top_container_collection_display_string_#{instance_count}"] = collection
-                                    .select { |c| c['display_string'].present? }
-                                    .map { |c| c['display_string'] }
-                                    .join("; ")
-                            end
+                request["instance_top_container_long_display_string_#{instance_count}"] = top_container_resolved['long_display_string']
+                request["instance_top_container_last_modified_by_#{instance_count}"] = top_container_resolved['last_modified_by']
+                request["instance_top_container_display_string_#{instance_count}"] = top_container_resolved['display_string']
+                request["instance_top_container_restricted_#{instance_count}"] = top_container_resolved['restricted']
+                request["instance_top_container_created_by_#{instance_count}"] = top_container_resolved['created_by']
+                request["instance_top_container_indicator_#{instance_count}"] = top_container_resolved['indicator']
+                request["instance_top_container_barcode_#{instance_count}"] = top_container_resolved['barcode']
+                request["instance_top_container_type_#{instance_count}"] = top_container_resolved['type']
+                request["instance_top_container_uri_#{instance_count}"] = top_container_resolved['uri']
 
-                            series = top_container_resolved['series']
-                            if series
-                                request["instance_top_container_series_identifier_#{instance_count}"] = series
-                                    .select { |s| s['identifier'].present? }
-                                    .map { |s| s['identifier'] }
-                                    .join("; ")
 
-                                request["instance_top_container_series_display_string_#{instance_count}"] = series
-                                    .select { |s| s['display_string'].present? }
-                                    .map { |s| s['display_string'] }
-                                    .join("; ")
-                            end
+                collection = top_container_resolved['collection']
+                if collection
+                    request["instance_top_container_collection_identifier_#{instance_count}"] = collection
+                        .select { |c| c['identifier'].present? }
+                        .map { |c| c['identifier'] }
+                        .join("; ")
 
-                        end
-                    end
+                    request["instance_top_container_collection_display_string_#{instance_count}"] = collection
+                        .select { |c| c['display_string'].present? }
+                        .map { |c| c['display_string'] }
+                        .join("; ")
+                end
+
+                series = top_container_resolved['series']
+                if series
+                    request["instance_top_container_series_identifier_#{instance_count}"] = series
+                        .select { |s| s['identifier'].present? }
+                        .map { |s| s['identifier'] }
+                        .join("; ")
+
+                    request["instance_top_container_series_display_string_#{instance_count}"] = series
+                        .select { |s| s['display_string'].present? }
+                        .map { |s| s['display_string'] }
+                        .join("; ")
+
                 end
 
                 request

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -305,6 +305,10 @@ class AeonRecordMapper
         return mappings
     end
 
+    # Grabs a list of instances from the given jsonmodel, ignoring any digital object
+    # instances. If the current jsonmodel does not have any top container instances, the
+    # method will recurse up the record's resource tree, until it finds a record that does
+    # have top container instances, and will pull the list of instances from there.
     def find_container_instances (record_json)
 
         current_uri = record_json['uri']

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -11,16 +11,16 @@ class AeonRecordMapper
     end
 
     def self.register_for_record_type(type)
-      @@mappers[type] = self
+        @@mappers[type] = self
     end
 
     def self.mapper_for(record)
-      if @@mappers.has_key?(record.class)
-        @@mappers[record.class].new(record)
-      else
-        Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
-        raise
-      end
+        if @@mappers.has_key?(record.class)
+            @@mappers[record.class].new(record)
+        else
+            Rails.logger.info("Aeon Fulfillment Plugin -- This ArchivesSpace object type (#{record.class}) is not supported by this plugin.")
+            raise
+        end
     end
 
     def repo_code


### PR DESCRIPTION
Added a separate method for getting the top container instances from a record. Digital object instances are still ignored from this list.

- If the record has top container instances, then those will be used.
- If the record does not have any top container instances, then the method will walk up the record's resource tree (checking to see if the record has a "parent" or a "resource") and will look for a record that does have top container instances. If one is found, then the top container instance information will be pulled from that record.
- If no top container instances are found for the current record, nor for any of the ancestors of the current record, then the mapper declares that the current record does not have any top container instances, and will continue on as normal.

This new functionality does not add any new settings, but does slightly change the functionality of the `:requests_permitted_for_containers_only` setting. If the current record does not have instance information, but a parent record does, and this setting is active, then the record will be requestable.