### PR TITLE
Bugfixes for Compatibility with v2.6.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # ArchivesSpace Request Fulfillment via Aeon
 
-**Version:** 20190115
+**Version:** 20190529
 
-**Last Updated:** January 15, 2019
+**Last Updated:** May 29, 2019
 
 
 ## Table of Contents
@@ -141,7 +141,9 @@ ArchivesSpace may cause changes in the functionality of this plugin.
     - The plugin now removes all HTML tags from form values
 - **20190115**
     - Added the `:user_defined_fields` setting
-
+- **20190529**
+    - Bug fixes for compatibility with ArchivesSpace v2.6.0 RC1
+        
 ## Configuring Plugin Settings
 
 In order to configure this plugin, you will need to modify the

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   plugins:
     aeon_fulfillment:
-      request_button_icon: fa fa-external-link fa-3x
+      request_button_icon: fa fa-external-link fa-external-link-alt fa-3x
       request_button_label: Aeon Request
       requesting_disabled: Requesting is not available for this record.

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -9,6 +9,9 @@ class AeonAccessionMapper < AeonRecordMapper
     def json_fields
         mappings = super
 
+        json = self.record.json
+        return mappings unless json
+
         accession_identifier = [ json['id_0'], json['id_1'], json['id_2'], json['id_3'] ]
         mappings['accession_id'] = accession_identifier
             .reject {|id_comp| id_comp.blank?}

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -34,6 +34,6 @@ class AeonAccessionMapper < AeonRecordMapper
 
         mappings['language'] = self.record['language']
 
-        return mappings
+        mappings
     end
 end

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -25,7 +25,7 @@ class AeonArchivalObjectMapper < AeonRecordMapper
             mappings['repository_processing_note'] = json['repository_processing_note']
         end
 
-        return mappings
+        mappings
     end
 
     # Returns a hash that maps from Aeon OpenURL values to values in the provided record.
@@ -34,6 +34,6 @@ class AeonArchivalObjectMapper < AeonRecordMapper
 
         mappings['component_id'] = self.record['component_id']
 
-        return mappings
+        mappings
     end
 end

--- a/public/models/aeon_archival_object_mapper.rb
+++ b/public/models/aeon_archival_object_mapper.rb
@@ -12,7 +12,7 @@ class AeonArchivalObjectMapper < AeonRecordMapper
         return self.requestable_based_on_archival_record_level?
     end
 
-    # Override for AeonRecordMapper json_fields method. 
+    # Override for AeonRecordMapper json_fields method.
     def json_fields
         mappings = super
 

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -10,7 +10,7 @@ class AeonRecordMapper
         @record = record
         @container_instances = find_container_instances(record['json'] || {})
     end
-    
+
     def archivesspace
         ArchivesSpaceClient.instance
     end
@@ -41,7 +41,7 @@ class AeonRecordMapper
 
         if (udf_setting = self.repo_settings[:user_defined_fields])
             if (user_defined_fields = (self.record['json'] || {})['user_defined'])
-            
+
                 # Determine if the list is a whitelist or a blacklist of fields.
                 # If the setting is just an array, assume that the list is a
                 # whitelist.
@@ -193,7 +193,7 @@ class AeonRecordMapper
     # Pulls data from AppConfig and ASpace System
     def system_information
         mappings = {}
-        
+
         mappings['SystemID'] =
             if (!self.repo_settings[:aeon_external_system_id].blank?)
                 self.repo_settings[:aeon_external_system_id]
@@ -251,7 +251,7 @@ class AeonRecordMapper
                 mappings['collection_id'] = collection_id_components
                     .reject {|id_comp| id_comp.blank?}
                     .join('-')
-                    
+
                 mappings['collection_title'] = resource_obj[0]['title']
             end
         end
@@ -292,7 +292,7 @@ class AeonRecordMapper
                 .map { |note| note['content'] }
                 .flatten
                 .join("; ")
-            
+
             mappings['accessrestrict'] = notes
                 .select { |note| note['type'] == 'accessrestrict' and note['subnotes'] }
                 .map { |note| note['subnotes'] }
@@ -403,7 +403,7 @@ class AeonRecordMapper
     def find_container_instances (record_json)
 
         current_uri = record_json['uri']
-        
+
         Rails.logger.info("Aeon Fulfillment Plugin") { "Checking \"#{current_uri}\" for Top Container instances..." }
         Rails.logger.debug("Aeon Fulfillment Plugin") { "#{record_json.to_json}" }
 
@@ -424,14 +424,14 @@ class AeonRecordMapper
             parent_uri = record_json['resource']['ref']
             parent_uri = record_json['resource'] unless parent_uri.present?
         end
-        
+
         if parent_uri.present?
             Rails.logger.debug("Aeon Fulfillment Plugin") { "No Top Container instances found. Checking parent. (#{parent_uri})" }
             parent = archivesspace.get_record(parent_uri)
             parent_json = parent['json']
             return find_container_instances(parent_json)
         end
-        
+
         Rails.logger.debug("Aeon Fulfillment Plugin") { "No Top Container instances found." }
 
         []

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -186,7 +186,7 @@ class AeonRecordMapper
             .merge(self.record_fields)
             .merge(self.user_defined_fields)
 
-        return mappings
+        mappings
     end
 
 
@@ -228,6 +228,8 @@ class AeonRecordMapper
     # Pulls data from self.record
     def record_fields
         mappings = {}
+
+        Rails.logger.debug("Aeon Fulfillment Plugin") { "Mapping Record: #{self.record}" }
 
         mappings['identifier'] = self.record.identifier || self.record['identifier']
         mappings['publish'] = self.record['publish']
@@ -279,7 +281,7 @@ class AeonRecordMapper
         json = self.record.json
         return mappings unless json
 
-        Rails.logger.debug("Aeon Fulfillment Plugin") { "json: #{json}" }
+        Rails.logger.debug("Aeon Fulfillment Plugin") { "Mapping Record JSON: #{json}" }
 
         mappings['language'] = json['language']
 

--- a/public/models/aeon_resource_mapper.rb
+++ b/public/models/aeon_resource_mapper.rb
@@ -11,7 +11,8 @@ class AeonResourceMapper < AeonRecordMapper
     # Override of #show_action? from AeonRecordMapper
     def show_action?
         return false if !super
-        return self.requestable_based_on_archival_record_level?
+
+        self.requestable_based_on_archival_record_level?
     end
 
     # Override for AeonRecordMapper json_fields method.

--- a/public/models/aeon_resource_mapper.rb
+++ b/public/models/aeon_resource_mapper.rb
@@ -7,14 +7,14 @@ class AeonResourceMapper < AeonRecordMapper
     def initialize(resource)
         super(resource)
     end
-    
+
     # Override of #show_action? from AeonRecordMapper
     def show_action?
         return false if !super
         return self.requestable_based_on_archival_record_level?
     end
 
-    # Override for AeonRecordMapper json_fields method. 
+    # Override for AeonRecordMapper json_fields method.
     def json_fields
         mappings = super
 
@@ -24,7 +24,7 @@ class AeonResourceMapper < AeonRecordMapper
         if json['repository_processing_note'] && json['repository_processing_note'].present?
             mappings['repository_processing_note'] = json['repository_processing_note']
         end
-        
+
         resource_identifier = [ json['id_0'], json['id_1'], json['id_2'], json['id_3'] ]
         mappings['collection_id'] = resource_identifier
             .reject {|id_comp| id_comp.blank?}

--- a/public/models/aeon_resource_mapper.rb
+++ b/public/models/aeon_resource_mapper.rb
@@ -19,9 +19,7 @@ class AeonResourceMapper < AeonRecordMapper
         mappings = super
 
         json = self.record.json
-        if !json
-            return mappings
-        end
+        return mappings unless json
 
         if json['repository_processing_note'] && json['repository_processing_note'].present?
             mappings['repository_processing_note'] = json['repository_processing_note']

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -40,6 +40,6 @@ mapper = AeonRecordMapper.mapper_for(record)
 
 <% end %>
 
-<% 
+<%
   Rails.logger.info("Aeon Fulfillment Plugin") { "Finished initializing plugin." }
 %>

--- a/public/views/aeon/_aeon_request_action.html.erb
+++ b/public/views/aeon/_aeon_request_action.html.erb
@@ -31,7 +31,7 @@ mapper = AeonRecordMapper.mapper_for(record)
 
     <div id="disabled-button-wrapper" tabindex="0" rel="tooltip" data-placement="bottom" title="<%= t('plugins.aeon_fulfillment.requesting_disabled') %>">
       <button id="disabled-aeon-fulfillment-request" class="btn btn-default page_action request" disabled="true" aria-disabled="true">
-        <i class="fa fa-external-link fa-3x"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
+        <i class="<%= t('plugins.aeon_fulfillment.request_button_icon') %>"></i><br/><%= t('plugins.aeon_fulfillment.request_button_label') %>
         <span class="visually-hidden"><%= t('plugins.aeon_fulfillment.requesting_disabled') %></span>
       </button>
     </div>


### PR DESCRIPTION
This PR includes changes that make the plugin compatible with ArchivesSpace v2.6.0, along with other various bugfixes. These changes are backwards compatible with ArchivesSpace v2.5.2.

- The Font Awesome package appears to be different between v2.5.2 and v2.6.0. [The old class now refers to a "Pro" icon](https://fontawesome.com/icons?d=gallery&q=external-link). This PR adds `fa-external-link-alt` to the CSS class for the request button icon.
- The AeonAccessionMapper was missing a reference to the Accession record's json component.
- [The Record viewmodel for the PUI was changed slightly between v2.5.2 and v2.6.0](https://github.com/archivesspace/archivesspace/pull/1511). This PR reduces the plugin's reliance on the PUI viewmodels by pulling "accessrestrict" note information directly from the JSON instead of the viewmodel.
- Code style changes, removing EOL whitespace and unnecessary `return`s.
- Adds a few DEBUG log statements to facilitate future debugging.