### PR TITLE
prevent crashes when initializing records from unconfigured repositories

### DIFF
--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -35,7 +35,7 @@ class AeonRecordMapper
     end
 
     def repo_settings
-        AppConfig[:aeon_fulfillment][self.repo_code]
+        AppConfig[:aeon_fulfillment][self.repo_code] || {}
     end
 
     def user_defined_fields


### PR DESCRIPTION
When initializing a record, `self.repo_settings` is now accessed before knowing whether the record's repository is defined in the plugin config.  This change simply returns an empty repo config when the repository is not defined in the plugin config, to prevent nil access crashes.