### PR TITLE
properly check for configured repositories now that repo_settings no longer returns nil

### DIFF
--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -96,7 +96,7 @@ class AeonRecordMapper
     end
 
     def unrequestable_display_message
-        if !(self.repo_settings)
+        if !(self.configured?)
             return "";
         end
 
@@ -130,7 +130,7 @@ class AeonRecordMapper
     # on the settings for the repository and defaults to false.
     def hide_button?
         # returning false to maintain the original behavior
-        return false unless self.repo_settings
+        return false unless self.configured?
 
         if self.repo_settings[:hide_request_button]
             return true

--- a/public/models/aeon_record_mapper.rb
+++ b/public/models/aeon_record_mapper.rb
@@ -123,7 +123,7 @@ class AeonRecordMapper
     end
     
     def configured?
-        return true if self.repo_settings
+        return true if self.repo_settings.present?
     end
 
     # This method tests whether the button should be hidden. This determination is based


### PR DESCRIPTION
My previous PR #42 has the side effect of causing every repository to display the request button, even if not configured.  This change improves how the plugin checks for a configured repository, and uses that check everywhere else that this condition was being tested.